### PR TITLE
use options object with encoding property

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,7 +37,7 @@ function bundle(cwd, options, done) {
     if (!inline) {
       vertname = vert
       vert = resolve.sync(vert, { basedir: cwd })
-      vert = fs.createReadStream(vert, 'utf8')
+      vert = fs.createReadStream(vert, { encoding: 'utf8' })
     } else {
       vert = from([vert])
     }
@@ -47,7 +47,7 @@ function bundle(cwd, options, done) {
     if (!inline) {
       fragname = frag
       frag = resolve.sync(frag, { basedir: cwd })
-      frag = fs.createReadStream(frag, 'utf8')
+      frag = fs.createReadStream(frag, { encoding: 'utf8' })
     } else {
       frag = from([frag])
     }


### PR DESCRIPTION
It looks like the `glslify-live` dependency in `shader-school` is using version `^1.02` of `glslify-bundle` and it is causing an error when it tries to create a read stream using `'utf8'` as an option. Newer versions of node are a little more strict and require this to be an object.

This PR just changes this. Stumbled on this problem when trying to get `shader-school` working for me - https://github.com/stackgl/shader-school/issues/126. It might be a better solution to have `glslify-live` use the newest version of `glslify-bundle`, but I noticed a different bug with just doing that change - this is just a fix to get it working for now. :smiley_cat: 
